### PR TITLE
[ISSUE] Implement positionless std::find_if alternative

### DIFF
--- a/Sources/Positionless/Algorithms/Partition.swift
+++ b/Sources/Positionless/Algorithms/Partition.swift
@@ -1,0 +1,37 @@
+extension MutableCollection {
+  /// Reorders the collection in place so that all elements matching the predicate
+  /// are moved into the suffix, preserving the relative order of the non-matching
+  /// elements. The resulting partition is then projected and passed to `f`.
+  ///
+  /// - Postcondition: For resulting partition `p`, `p.partitionCount == 2`.
+  ///
+  /// - Complexity: Exactly `count` predicate application. No more than `count` swaps.
+  mutating func halfStablePartition<R>(by predicate: (Element) -> Bool, _ f: (MutableParts) -> R)
+    -> R
+  {
+    return mutableSplitFirst(where: predicate) { bisection in
+      if bisection[part: 1].isEmpty() {
+        return f(bisection)
+      }
+
+      bisection.withAdditionalMutableParts(1) { trisection in
+        trisection.transferAllToNext(from: 1)
+        /// Loop Invariant:
+        /// - `trisection[part: 0]` contains elements that don't satisfy the predicate.
+        /// - `trisection[part: 1]` contains elements that satisfy the predicate.
+        /// - `trisection[part: 2]` contain remaining elements to be processed.
+        while !trisection[part: 2].isEmpty() {
+          if predicate(trisection[part: 2].first) {
+            trisection.grow(part: 1)
+          } else {
+            trisection.swapFirst(1, 2)
+            trisection.grow(part: 0)
+            trisection.grow(part: 1)
+          }
+        }
+      }
+
+      return f(bisection)
+    }
+  }
+}

--- a/Sources/Positionless/Algorithms/Partition.swift
+++ b/Sources/Positionless/Algorithms/Partition.swift
@@ -2,7 +2,8 @@ extension MutableCollection {
 
   /// Reorders the collection in place so that all elements matching the predicate
   /// are moved into the suffix, preserving the relative order of only non-matching
-  /// elements. The resulting partition is then projected and passed to `f`.
+  /// elements. The resulting partition is then projected and passed to `f` with
+  /// returning its result.
   ///
   /// - Postcondition: For resulting partition `p`, `p.partitionCount == 2`.
   ///
@@ -10,15 +11,15 @@ extension MutableCollection {
   mutating func halfStablePartition<R>(by predicate: (Element) -> Bool, _ f: (MutableParts) -> R)
     -> R
   {
-    return withMutableParts(count: 2) {
-      $0.halfStablePartition(by: predicate)
-      return f($0)
+    return withMutableParts(count: 2) { p in
+      p.halfStablePartition(by: predicate)
+      return f(p)
     }
   }
 
   /// Reorders the collection in place so that all elements matching the predicate
   /// are moved into the suffix, preserving the relative order of each part.
-  /// The resulting partition is then projected and passed to `f`.
+  /// The resulting partition is then projected and passed to `f` with returning its result.
   ///
   /// - Postcondition: For resulting partition `p`, `p.partitionCount == 2`.
   ///
@@ -127,4 +128,5 @@ extension MutablePartitioning {
       p.shiftSections(from: 3, to: 1)  // prefix | suffix | _ | _
     }
   }
+
 }

--- a/Sources/Positionless/Algorithms/Partition.swift
+++ b/Sources/Positionless/Algorithms/Partition.swift
@@ -1,4 +1,5 @@
 extension MutableCollection {
+
   /// Reorders the collection in place so that all elements matching the predicate
   /// are moved into the suffix, preserving the relative order of only non-matching
   /// elements. The resulting partition is then projected and passed to `f`.
@@ -9,29 +10,121 @@ extension MutableCollection {
   mutating func halfStablePartition<R>(by predicate: (Element) -> Bool, _ f: (MutableParts) -> R)
     -> R
   {
-    return mutableSplitFirst(where: predicate) { bisection in
-      if bisection[part: 1].isEmpty() {
-        return f(bisection)
-      }
+    return withMutableParts(count: 2) {
+      $0.halfStablePartition(by: predicate)
+      return f($0)
+    }
+  }
 
-      bisection.withAdditionalMutableParts(1) { trisection in
-        trisection.transferAllToNext(from: 1)
-        /// Loop Invariant:
-        /// - `trisection[part: 0]` contains elements that don't satisfy the predicate.
-        /// - `trisection[part: 1]` contains elements that satisfy the predicate.
-        /// - `trisection[part: 2]` contains the unexamined remainder of collection.
-        while !trisection[part: 2].isEmpty() {
-          if predicate(trisection[part: 2].first) {
-            trisection.grow(part: 1)
-          } else {
-            trisection.swapFirst(1, 2)
-            trisection.grow(part: 0)
-            trisection.grow(part: 1)
-          }
+  /// Reorders the collection in place so that all elements matching the predicate
+  /// are moved into the suffix, preserving the relative order of each part.
+  /// The resulting partition is then projected and passed to `f`.
+  ///
+  /// - Postcondition: For resulting partition `p`, `p.partitionCount == 2`.
+  ///
+  /// - Complexity: Exactly `count` `predicate` application. At most `count.log2(count)` swaps.
+  mutating func stablePartition<R>(by predicate: (Element) -> Bool, _ f: (MutableParts) -> R)
+    -> R
+  {
+    return withMutableParts(count: 2) { p in
+      p.stablePartition(by: predicate)
+      return f(p)
+    }
+  }
+
+}
+
+extension MutablePartitioning {
+
+  /// Reorders the collection in place so that all elements matching the predicate
+  /// are moved into `parts[1]` and rest into `parts[0]`, preserving the
+  /// relative ordering of `parts[0]` only.
+  ///
+  /// - Precondition:
+  ///   - `partitionCount == 2`,
+  ///   - `self[part: 0].isEmpty()`.
+  ///
+  /// - Complexity: Exactly `n` predicate application. No more than `n` swaps.
+  ///   where `n == self[part: 1].count`.
+  mutating func halfStablePartition(by predicate: (SubSeq.Element) -> Bool) {
+    grow(part: 0, until: predicate)
+    if self[part: 1].isEmpty() {
+      return
+    }
+
+    withAdditionalMutableParts(1) { p in
+      p.transferAllToNext(from: 1)
+      /// Loop Invariant:
+      /// - `p[part: 0]` contains elements that don't satisfy the predicate.
+      /// - `p[part: 1]` contains elements that satisfy the predicate.
+      /// - `p[part: 2]` contains the unexamined remainder of collection.
+      while !p[part: 2].isEmpty() {
+        if predicate(p[part: 2].first) {
+          p.grow(part: 1)
+        } else {
+          p.swapFirst(1, 2)
+          p.grow(part: 0)
+          p.grow(part: 1)
         }
       }
+    }
 
-      return f(bisection)
+  }
+
+  /// Reorders the collection in place so that all elements matching the predicate
+  /// are moved into the `parts[1]` and rest into `parts[0]`, preserving the
+  /// relative order of each part.
+  ///
+  /// - Precondition:
+  ///   - `partitionCount == 2`,
+  ///   - `self[part: 0].isEmpty()`.
+  ///
+  /// - Complexity: Exactly `n` `predicate` application. At most `n.log2(n)` swaps.
+  ///   where `n == self[part: 1].count`.
+  mutating func stablePartition(by predicate: (SubSeq.Element) -> Bool) {
+    let n = self[part: 1].count
+    stablePartition(by: predicate, count: n)
+  }
+
+  /// Reorders the collection in place so that all elements matching the predicate
+  /// are moved into the `parts[1]` and rest into `parts[0]`, preserving the
+  /// relative order of each part.
+  ///
+  /// - Precondition:
+  ///   - `partitionCount == 2`,
+  ///   - `self[part: 0].isEmpty()`,
+  ///   - `n == self[part: 1].count`.
+  ///
+  /// - Complexity: Exactly `n` `predicate` application. At most `n.log2(n)` swaps.
+  private mutating func stablePartition(by predicate: (SubSeq.Element) -> Bool, count n: Int) {
+    // _ | _
+    if n == 0 {
+      return
+    }
+
+    // _ | E
+    if n == 1 {
+      if !predicate(self[part: 1].first) {
+        grow(part: 0)  // E | _
+      }
+      return
+    }
+
+    withAdditionalMutableParts(2) { p in
+      // _ | E | _ | _
+      p.transferAllToNext(from: 1)  // _ | _ | E | _
+      let h = n / 2
+      p.grow(part: 1, by: h)  // _ | h | n - h | _
+      p.transferAllToNext(from: 2)  // _ | h | _ | n - h
+
+      // Stable partition [_ | h] bisection
+      p.withMutableParts(from: 0, to: 1) { $0.stablePartition(by: predicate, count: h) }
+      // Stable partition [_ | n - h] bisection
+      p.withMutableParts(from: 2, to: 3) { $0.stablePartition(by: predicate, count: n - h) }
+      p.withMutableParts(from: 1, to: 2) { $0.rotate() }  // merge step
+
+      p.transferAllToPrev(from: 1)
+      p.shiftSections(from: 3, to: 1)  // prefix | suffix | _ | _
     }
   }
 }

--- a/Sources/Positionless/Algorithms/Partition.swift
+++ b/Sources/Positionless/Algorithms/Partition.swift
@@ -1,6 +1,6 @@
 extension MutableCollection {
   /// Reorders the collection in place so that all elements matching the predicate
-  /// are moved into the suffix, preserving the relative order of the non-matching
+  /// are moved into the suffix, preserving the relative order of only non-matching
   /// elements. The resulting partition is then projected and passed to `f`.
   ///
   /// - Postcondition: For resulting partition `p`, `p.partitionCount == 2`.
@@ -19,7 +19,7 @@ extension MutableCollection {
         /// Loop Invariant:
         /// - `trisection[part: 0]` contains elements that don't satisfy the predicate.
         /// - `trisection[part: 1]` contains elements that satisfy the predicate.
-        /// - `trisection[part: 2]` contain remaining elements to be processed.
+        /// - `trisection[part: 2]` contains the unexamined remainder of collection.
         while !trisection[part: 2].isEmpty() {
           if predicate(trisection[part: 2].first) {
             trisection.grow(part: 1)

--- a/Sources/Positionless/Algorithms/Searching.swift
+++ b/Sources/Positionless/Algorithms/Searching.swift
@@ -6,7 +6,10 @@ extension Collection {
   ///   - `part[1]` contains the first matching element and all elements after it.
   ///
   /// - Complexity: O(`count`).
-  func splitFirst<R>(where predicate: (Element) -> Bool, _ f: (inout Parts) -> R) -> R {
+  func splitFirst<R>(
+    where predicate: (Element) -> Bool,
+    _ f: (inout Parts) -> R
+  ) -> R {
     return withParts(count: 2) { p in
       while !p[part: 1].isEmpty() {
         if predicate(p[part: 1].first) {
@@ -27,7 +30,10 @@ extension MutableCollection {
   ///   - `part[1]` contains the first matching element and all elements after it.
   ///
   /// - Complexity: O(`count`).
-  mutating func splitFirstMut<R>(where predicate: (Element) -> Bool, _ f: (inout Parts) -> R)
+  mutating func mutableSplitFirst<R>(
+    where predicate: (Element) -> Bool,
+    _ f: (inout Parts) -> R
+  )
     -> R
   {
     return withMutableParts(count: 2) { p in

--- a/Sources/Positionless/Algorithms/Searching.swift
+++ b/Sources/Positionless/Algorithms/Searching.swift
@@ -1,6 +1,6 @@
 extension Partitioning {
 
-  /// Grows given part until first element next part satisfies given predicate or becomes empty.
+  /// Grows given part until first element of next part satisfies `predicate` or becomes empty.
   ///
   /// - Precondition: `i < partitionCount - 1`
   ///
@@ -63,7 +63,7 @@ extension MutableCollection {
   /// - Complexity: O(`count`).
   mutating func mutableSplitFirst<R>(
     where predicate: (Element) -> Bool,
-    _ f: (inout Parts) -> R
+    _ f: (inout MutableParts) -> R
   )
     -> R
   {
@@ -82,7 +82,7 @@ extension MutableCollection {
   /// - Complexity: O(`count`).
   mutating func mutableSplitFirst<R>(
     on e: Element,
-    _ f: (inout Parts) -> R
+    _ f: (inout MutableParts) -> R
   ) -> R
   where Element: Equatable {
     mutableSplitFirst(where: { $0 == e }, f)

--- a/Sources/Positionless/Algorithms/Searching.swift
+++ b/Sources/Positionless/Algorithms/Searching.swift
@@ -1,4 +1,5 @@
 extension Collection {
+
   /// Splits the collection at the first element that satisfies the given predicate.
   ///
   /// - Postcondition:
@@ -20,9 +21,26 @@ extension Collection {
       return f(&p)
     }
   }
+
+  /// Splits the collection at the first element that is equal to given element.
+  ///
+  /// - Postcondition:
+  ///   - `part[0]` contains all elements before the first match.
+  ///   - `part[1]` contains the first matching element and all elements after it.
+  ///
+  /// - Complexity: O(`count`).
+  func splitFirst<R>(
+    on e: Element,
+    _ f: (inout Parts) -> R
+  ) -> R
+  where Element: Equatable {
+    splitFirst(where: { $0 == e }, f)
+  }
+
 }
 
 extension MutableCollection {
+
   /// Splits the collection at the first element that satisfies the given predicate.
   ///
   /// - Postcondition:
@@ -46,4 +64,20 @@ extension MutableCollection {
       return f(&p)
     }
   }
+
+  /// Splits the collection at the first element that is equal to given element.
+  ///
+  /// - Postcondition:
+  ///   - `part[0]` contains all elements before the first match.
+  ///   - `part[1]` contains the first matching element and all elements after it.
+  ///
+  /// - Complexity: O(`count`).
+  mutating func mutableSplitFirst<R>(
+    on e: Element,
+    _ f: (inout Parts) -> R
+  ) -> R
+  where Element: Equatable {
+    mutableSplitFirst(where: { $0 == e }, f)
+  }
+
 }

--- a/Sources/Positionless/Algorithms/Searching.swift
+++ b/Sources/Positionless/Algorithms/Searching.swift
@@ -1,3 +1,21 @@
+extension Partitioning {
+
+  /// Grows given part until first element next part satisfies given predicate or becomes empty.
+  ///
+  /// - Precondition: `i < partitionCount - 1`
+  ///
+  /// - Complexity: No more than `self[part: i + 1].count` to `grow`.
+  mutating func grow(part i: Int, until predicate: (SubSeq.Element) -> Bool) {
+    while !self[part: i + 1].isEmpty() {
+      if predicate(self[part: i + 1].first) {
+        break
+      }
+      grow(part: i)
+    }
+  }
+
+}
+
 extension Collection {
 
   /// Splits the collection at the first element that satisfies the given predicate.
@@ -12,12 +30,7 @@ extension Collection {
     _ f: (inout Parts) -> R
   ) -> R {
     return withParts(count: 2) { p in
-      while !p[part: 1].isEmpty() {
-        if predicate(p[part: 1].first) {
-          break
-        }
-        p.grow(part: 0)
-      }
+      p.grow(part: 0, until: predicate)
       return f(&p)
     }
   }
@@ -55,12 +68,7 @@ extension MutableCollection {
     -> R
   {
     return withMutableParts(count: 2) { p in
-      while !p[part: 1].isEmpty() {
-        if predicate(p[part: 1].first) {
-          break
-        }
-        p.grow(part: 0)
-      }
+      p.grow(part: 0, until: predicate)
       return f(&p)
     }
   }

--- a/Sources/Positionless/Algorithms/Searching.swift
+++ b/Sources/Positionless/Algorithms/Searching.swift
@@ -6,7 +6,7 @@ extension Collection {
   ///   - `part[1]` contains the first matching element and all elements after it.
   ///
   /// - Complexity: O(`count`).
-  func splitFirstWhere<R>(where predicate: (Element) -> Bool, _ f: (inout Parts) -> R) -> R {
+  func splitFirst<R>(where predicate: (Element) -> Bool, _ f: (inout Parts) -> R) -> R {
     return withParts(count: 2) { p in
       while !p[part: 1].isEmpty() {
         if predicate(p[part: 1].first) {
@@ -27,7 +27,7 @@ extension MutableCollection {
   ///   - `part[1]` contains the first matching element and all elements after it.
   ///
   /// - Complexity: O(`count`).
-  mutating func splitFirstWhereMut<R>(where predicate: (Element) -> Bool, _ f: (inout Parts) -> R)
+  mutating func splitFirstMut<R>(where predicate: (Element) -> Bool, _ f: (inout Parts) -> R)
     -> R
   {
     return withMutableParts(count: 2) { p in

--- a/Sources/Positionless/Algorithms/Searching.swift
+++ b/Sources/Positionless/Algorithms/Searching.swift
@@ -1,0 +1,43 @@
+extension Collection {
+  /// Splits the collection at the first element that satisfies the given predicate.
+  ///
+  /// - Postcondition:
+  ///   - `part[0]` contains all elements before the first match.
+  ///   - `part[1]` contains the first matching element and all elements after it.
+  ///
+  /// - Complexity: O(`count`).
+  func splitFirstWhere<R>(where predicate: (Element) -> Bool, _ f: (inout Parts) -> R) -> R {
+    return withParts(count: 2) { p in
+      while !p[part: 1].isEmpty() {
+        if predicate(p[part: 1].first) {
+          break
+        }
+        p.grow(part: 0)
+      }
+      return f(&p)
+    }
+  }
+}
+
+extension MutableCollection {
+  /// Splits the collection at the first element that satisfies the given predicate.
+  ///
+  /// - Postcondition:
+  ///   - `part[0]` contains all elements before the first match.
+  ///   - `part[1]` contains the first matching element and all elements after it.
+  ///
+  /// - Complexity: O(`count`).
+  mutating func splitFirstWhereMut<R>(where predicate: (Element) -> Bool, _ f: (inout Parts) -> R)
+    -> R
+  {
+    return withMutableParts(count: 2) { p in
+      while !p[part: 1].isEmpty() {
+        if predicate(p[part: 1].first) {
+          break
+        }
+        p.grow(part: 0)
+      }
+      return f(&p)
+    }
+  }
+}

--- a/Sources/Positionless/Algorithms/SinglePass.swift
+++ b/Sources/Positionless/Algorithms/SinglePass.swift
@@ -23,6 +23,13 @@ extension Collection {
     }
   }
 
+  /// Returns true iff all elements satisfy the given predicate.
+  ///
+  /// - Complexity: No more than `count` application of `predicate`.
+  func all(satisfy predicate: (Element) -> Bool) -> Bool {
+    return !forEach(until: { !predicate($0) })
+  }
+
   /// Returns the number of elements.
   func count() -> Int {
     var r = 0

--- a/Sources/Positionless/Collection.swift
+++ b/Sources/Positionless/Collection.swift
@@ -63,6 +63,17 @@ protocol Partitioning: ~Copyable {
   /// The elements in additional parts of projection are appended to last part.
   mutating func withAdditionalParts<R>(_ n: Int, _ f: (inout SubSeq.Parts) -> R) -> R
 
+  /// Returns the result of passing to `f` the projection of self containing
+  /// parts in `[from, to]`.
+  ///
+  /// - Precondition:
+  ///   - `from <= to`
+  ///   - `from >= 0 && from < partitionCount`.
+  ///   - `to >= 0 && to < partitionCount`.
+  ///
+  /// - Postcondition: `self` adopts the boundaries of projected partitioning.
+  mutating func withParts<R>(from: Int, to: Int, _ f: (inout SubSeq.Parts) -> R) -> R
+
   /// Returns the result of passing to `f` the independent projection of `self`.
   mutating func withProjection<R>(_ f: (inout SubSeq.Parts) -> R) -> R
 

--- a/Sources/Positionless/MutableCollection.swift
+++ b/Sources/Positionless/MutableCollection.swift
@@ -31,6 +31,19 @@ protocol MutablePartitioning: Partitioning {
     _ n: Int, _ f: (inout MutableSubSeq.MutableParts) -> R
   ) -> R
 
+  /// Returns the result of passing to `f` the mutable projection of self containing
+  /// parts in `[from, to]`.
+  ///
+  /// - Precondition:
+  ///   - `from <= to`
+  ///   - `from >= 0 && from < partitionCount`.
+  ///   - `to >= 0 && to < partitionCount`.
+  ///
+  /// - Postcondition: `self` adopts the boundaries of projected partitioning.
+  mutating func withMutableParts<R>(
+    from: Int, to: Int, _ f: (inout MutableSubSeq.MutableParts) -> R
+  ) -> R
+
   /// Returns the result of passing to `f` the independent mutable projection of `self`.
   mutating func withMutableProjection<R>(
     _ f: (inout MutableSubSeq.MutableParts) -> R

--- a/Sources/Positionless/MutableCollection.swift
+++ b/Sources/Positionless/MutableCollection.swift
@@ -6,6 +6,9 @@ protocol MutablePartitioning: Partitioning {
 
   /// The type of each part subsequence.
   associatedtype MutableSubSeq: MutableSlice
+  where
+    MutableSubSeq.Element == SubSeq.Element,
+    MutableSubSeq.SubSeq == SubSeq
 
   /// Swaps first element partition i and j.
   ///

--- a/Sources/Positionless/STDImpl/SlicePartitioning.swift
+++ b/Sources/Positionless/STDImpl/SlicePartitioning.swift
@@ -70,6 +70,15 @@ extension SlicePartitioning: Partitioning {
     return res
   }
 
+  mutating func withParts<R>(from: Int, to: Int, _ f: (inout SubSeq.Parts) -> R) -> R {
+    var partition = SlicePartitioning(storage, Array(partitionStartIndexes[from...to + 1]))
+    let res = f(&partition)
+    for i in from...to {
+      partitionStartIndexes[i] = partition.partitionStartIndexes[i]
+    }
+    return res
+  }
+
   mutating func withProjection<R>(_ f: (inout SlicePartitioning<Base>) -> R) -> R {
     var projection = SlicePartitioning(storage, partitionStartIndexes)
     return f(&projection)
@@ -139,6 +148,18 @@ where Base: Swift.MutableCollection {
       storage, partitionStartIndexes + Array(repeating: partitionStartIndexes.last!, count: n))
     let res = f(&partition)
     for i in 1..<partitionCount {
+      partitionStartIndexes[i] = partition.partitionStartIndexes[i]
+    }
+    _writeBackElements(from: partition.storage, to: &storage)
+    return res
+  }
+
+  mutating func withMutableParts<R>(
+    from: Int, to: Int, _ f: (inout MutableSubSeq.MutableParts) -> R
+  ) -> R {
+    var partition = SlicePartitioning(storage, Array(partitionStartIndexes[from...to + 1]))
+    let res = f(&partition)
+    for i in from + 1...to {
       partitionStartIndexes[i] = partition.partitionStartIndexes[i]
     }
     _writeBackElements(from: partition.storage, to: &storage)

--- a/Sources/Positionless/STDImpl/SlicePartitioning.swift
+++ b/Sources/Positionless/STDImpl/SlicePartitioning.swift
@@ -73,8 +73,8 @@ extension SlicePartitioning: Partitioning {
   mutating func withParts<R>(from: Int, to: Int, _ f: (inout SubSeq.Parts) -> R) -> R {
     var partition = SlicePartitioning(storage, Array(partitionStartIndexes[from...to + 1]))
     let res = f(&partition)
-    for i in from...to {
-      partitionStartIndexes[i] = partition.partitionStartIndexes[i]
+    for (i, j) in zip(from + 1...to, 1...) {
+      partitionStartIndexes[i] = partition.partitionStartIndexes[j]
     }
     return res
   }
@@ -159,8 +159,8 @@ where Base: Swift.MutableCollection {
   ) -> R {
     var partition = SlicePartitioning(storage, Array(partitionStartIndexes[from...to + 1]))
     let res = f(&partition)
-    for i in from + 1...to {
-      partitionStartIndexes[i] = partition.partitionStartIndexes[i]
+    for (i, j) in zip(from + 1...to, 1...) {
+      partitionStartIndexes[i] = partition.partitionStartIndexes[j]
     }
     _writeBackElements(from: partition.storage, to: &storage)
     return res

--- a/Tests/PositionlessTests/PartitionTest.swift
+++ b/Tests/PositionlessTests/PartitionTest.swift
@@ -41,3 +41,39 @@ private func isOdd(_ n: Int) -> Bool {
   }
 
 }
+
+@Suite("stablePartition(by:)") struct StablePartition {
+
+  @Test func whenBothPartsHaveSomeElements() {
+    var array = [1, 2, 3, 4, 5, 6]
+    array.stablePartition(by: isOdd) { p in
+      #expect(p[part: 0] == [2, 4, 6])
+      #expect(p[part: 1] == [1, 3, 5])
+    }
+  }
+
+  @Test func whenFirstPartIsEmpty() {
+    var array = [1, 3, 5]
+    array.stablePartition(by: isOdd) { p in
+      #expect(p[part: 0] == [])
+      #expect(p[part: 1] == [1, 3, 5])
+    }
+  }
+
+  @Test func whenSecondPartIsEmpty() {
+    var array = [2, 4, 6]
+    array.stablePartition(by: isOdd) { p in
+      #expect(p[part: 0] == [2, 4, 6])
+      #expect(p[part: 1] == [])
+    }
+  }
+
+  @Test func whenBothPartsAreEmpty() {
+    var array: [Int] = []
+    array.stablePartition(by: isOdd) { p in
+      #expect(p[part: 0] == [])
+      #expect(p[part: 1] == [])
+    }
+  }
+
+}

--- a/Tests/PositionlessTests/PartitionTest.swift
+++ b/Tests/PositionlessTests/PartitionTest.swift
@@ -1,0 +1,43 @@
+import Testing
+
+@testable import Positionless
+
+private func isOdd(_ n: Int) -> Bool {
+  return n % 2 == 1
+}
+
+@Suite("halfStablePartition(by:)") struct HalfStablePartition {
+
+  @Test func whenBothPartsHaveSomeElements() {
+    var array = [1, 2, 3, 4, 5, 6]
+    array.halfStablePartition(by: isOdd) { p in
+      #expect(p[part: 0] == [2, 4, 6])
+      #expect(p[part: 1].all(satisfy: isOdd))
+    }
+  }
+
+  @Test func whenFirstPartIsEmpty() {
+    var array = [1, 3, 5]
+    array.halfStablePartition(by: isOdd) { p in
+      #expect(p[part: 0] == [])
+      #expect(p[part: 1].all(satisfy: isOdd))
+    }
+  }
+
+  @Test func whenSecondPartIsEmpty() {
+    var array = [2, 4, 6]
+    array.halfStablePartition(by: isOdd) { p in
+      #expect(p[part: 0] == [2, 4, 6])
+      #expect(p[part: 1].all(satisfy: isOdd))
+    }
+  }
+
+  @Test func whenBothPartsAreEmpty() {
+    var array: [Int] = []
+    array.halfStablePartition(by: isOdd) { p in
+      #expect(p[part: 0] == [])
+      #expect(p[part: 1].all(satisfy: isOdd))
+    }
+  }
+
+}

--- a/Tests/PositionlessTests/SearchingTest.swift
+++ b/Tests/PositionlessTests/SearchingTest.swift
@@ -20,7 +20,7 @@ import Testing
     }
   }
 
-  @Test func allElementsSatisfyPredicate() {
+  @Test func firstElementSatisfyPredicate() {
     let array = [2, 4, 6]
     array.splitFirst(where: { $0 % 2 == 0 }) { p in
       #expect(p[part: 0] == [])
@@ -38,7 +38,7 @@ import Testing
 
 }
 
-@Suite("mutableSplitFirst(where:)") struct SplitFirstMutWhere {
+@Suite("mutableSplitFirst(where:)") struct MutableSplitFirstWhere {
 
   @Test func multipleElementsSatisfyPredicate() {
     var array = [1, 2, 3, 4, 5]
@@ -56,7 +56,7 @@ import Testing
     }
   }
 
-  @Test func allElementsSatisfyPredicate() {
+  @Test func firstElementSatisfyPredicate() {
     var array = [2, 4, 6]
     array.mutableSplitFirst(where: { $0 % 2 == 0 }) { p in
       #expect(p[part: 0] == [])
@@ -67,6 +67,78 @@ import Testing
   @Test func emptyArray() {
     var array: [Int] = []
     array.mutableSplitFirst(where: { $0 % 2 == 0 }) { p in
+      #expect(p[part: 0] == [])
+      #expect(p[part: 1] == [])
+    }
+  }
+
+}
+
+@Suite("splitFirst(on:)") struct SplitFirstOn {
+
+  @Test func multipleMatchPresent() {
+    let array = [1, 2, 3, 2, 5]
+    array.splitFirst(on: 2) { p in
+      #expect(p[part: 0] == [1])
+      #expect(p[part: 1] == [2, 3, 2, 5])
+    }
+  }
+
+  @Test func elementNotPresent() {
+    let array = [1, 3, 5]
+    array.splitFirst(on: 2) { p in
+      #expect(p[part: 0] == [1, 3, 5])
+      #expect(p[part: 1] == [])
+    }
+  }
+
+  @Test func matchBeingFirstElement() {
+    let array = [2, 4, 6]
+    array.splitFirst(on: 2) { p in
+      #expect(p[part: 0] == [])
+      #expect(p[part: 1] == [2, 4, 6])
+    }
+  }
+
+  @Test func emptyArray() {
+    let array: [Int] = []
+    array.splitFirst(on: 2) { p in
+      #expect(p[part: 0] == [])
+      #expect(p[part: 1] == [])
+    }
+  }
+
+}
+
+@Suite("mutableSplitFirst(on:)") struct MutableSplitFirstOn {
+
+  @Test func multipleMatchPresent() {
+    var array = [1, 2, 3, 2, 5]
+    array.mutableSplitFirst(on: 2) { p in
+      #expect(p[part: 0] == [1])
+      #expect(p[part: 1] == [2, 3, 2, 5])
+    }
+  }
+
+  @Test func elementNotPresent() {
+    var array = [1, 3, 5]
+    array.mutableSplitFirst(on: 2) { p in
+      #expect(p[part: 0] == [1, 3, 5])
+      #expect(p[part: 1] == [])
+    }
+  }
+
+  @Test func matchBeingFirstElement() {
+    var array = [2, 4, 6]
+    array.mutableSplitFirst(on: 2) { p in
+      #expect(p[part: 0] == [])
+      #expect(p[part: 1] == [2, 4, 6])
+    }
+  }
+
+  @Test func emptyArray() {
+    var array: [Int] = []
+    array.mutableSplitFirst(on: 2) { p in
       #expect(p[part: 0] == [])
       #expect(p[part: 1] == [])
     }

--- a/Tests/PositionlessTests/SearchingTest.swift
+++ b/Tests/PositionlessTests/SearchingTest.swift
@@ -1,0 +1,75 @@
+import Testing
+
+@testable import Positionless
+
+@Suite("splitFirst(where:)") struct SplitFirstWhere {
+
+  @Test func multipleElementsSatisfyPredicate() {
+    let array = [1, 2, 3, 4, 5]
+    array.splitFirst(where: { $0 % 2 == 0 }) { p in
+      #expect(p[part: 0] == [1])
+      #expect(p[part: 1] == [2, 3, 4, 5])
+    }
+  }
+
+  @Test func noElementSatisfyPredicate() {
+    let array = [1, 3, 5]
+    array.splitFirst(where: { $0 % 2 == 0 }) { p in
+      #expect(p[part: 0] == [1, 3, 5])
+      #expect(p[part: 1] == [])
+    }
+  }
+
+  @Test func allElementsSatisfyPredicate() {
+    let array = [2, 4, 6]
+    array.splitFirst(where: { $0 % 2 == 0 }) { p in
+      #expect(p[part: 0] == [])
+      #expect(p[part: 1] == [2, 4, 6])
+    }
+  }
+
+  @Test func emptyArray() {
+    let array: [Int] = []
+    array.splitFirst(where: { $0 % 2 == 0 }) { p in
+      #expect(p[part: 0] == [])
+      #expect(p[part: 1] == [])
+    }
+  }
+
+}
+
+@Suite("mutableSplitFirst(where:)") struct SplitFirstMutWhere {
+
+  @Test func multipleElementsSatisfyPredicate() {
+    var array = [1, 2, 3, 4, 5]
+    array.mutableSplitFirst(where: { $0 % 2 == 0 }) { p in
+      #expect(p[part: 0] == [1])
+      #expect(p[part: 1] == [2, 3, 4, 5])
+    }
+  }
+
+  @Test func noElementSatisfyPredicate() {
+    var array = [1, 3, 5]
+    array.mutableSplitFirst(where: { $0 % 2 == 0 }) { p in
+      #expect(p[part: 0] == [1, 3, 5])
+      #expect(p[part: 1] == [])
+    }
+  }
+
+  @Test func allElementsSatisfyPredicate() {
+    var array = [2, 4, 6]
+    array.mutableSplitFirst(where: { $0 % 2 == 0 }) { p in
+      #expect(p[part: 0] == [])
+      #expect(p[part: 1] == [2, 4, 6])
+    }
+  }
+
+  @Test func emptyArray() {
+    var array: [Int] = []
+    array.mutableSplitFirst(where: { $0 % 2 == 0 }) { p in
+      #expect(p[part: 0] == [])
+      #expect(p[part: 1] == [])
+    }
+  }
+
+}


### PR DESCRIPTION
As positions are not a thing, I believe we need to project bisection as an alternative to returning position from `std::find_if` algorithm where first part would contain elements before the first element that satisfies predicate and rest would be in second part.

Despite this being a simple algorithm, I have opened it as separate PR as I need to discuss implication of having mutable partitioning as a thing in our design.
In the code, we can see I needed to implement 2 algorithms: `splitFirst(where: )` and `splitFirstMut(where:)` as caller might or might not want to mutate the base collection using projected partitioning.

My motive was to implement `std::partition` algorithm and I needed `splitFirstMut` variant. But I think this is something bothering me as if any algorithm needs to project a partitioning, we need to provide 2 variants of it. First one with immutable partitioning and other one as mutable partitioning. This might lead to explosion of algorithms in future.

This similar problem is there in rs-stl for slices, but there algorithm just returns position and caller can choose if they need to create mutable slice or immutable slice using those positions.

@dabrahams your thoughts on this? Am I missing something here or over-complicating the things?